### PR TITLE
Compute number of grid columns from screen width

### DIFF
--- a/gallery.py
+++ b/gallery.py
@@ -225,7 +225,10 @@ class WindowManager():
     thumbSize = 'S'
     imgDim = THUMBNAIL_SIZES[thumbSize]
     loadingThumbPath = THUMBNAIL_LOAD_PATHS[thumbSize]
-    gridCols = 4
+    screenWidth, _ = sg.Window.get_screen_size()
+    scrollBarWidth = 20
+    frameExcessWidth = 28
+    gridCols = max(1, math.floor((screenWidth - scrollBarWidth)/(imgDim + frameExcessWidth)))
     folderData = FolderData()
     folderSettings = {
         'thumbSize': thumbSize,


### PR DESCRIPTION
In the Window class body, added constants for widths of window Elements, and user screen width.
Then use these to compute the max number of columns to fit on the screen.

Resolves https://github.com/dmjz/gallery/issues/1